### PR TITLE
Merge existing fixes and some new performance enhancements

### DIFF
--- a/bottle_mongo.py
+++ b/bottle_mongo.py
@@ -68,7 +68,6 @@ class MongoPlugin(object):
     """
 
     api = 2
-    name = "mongo"
 
     def get_mongo(self):
         """Return the mongo connection from the environment."""
@@ -109,6 +108,14 @@ class MongoPlugin(object):
 
         self.keyword = keyword
         self.json_mongo = json_mongo
+        self.mongo_db = None
+        self.name = "mongo:" + keyword
+
+    def __str__(self):
+        return "bottle_mongo.MongoPlugin(keyword=%r)" % (self.keyword)
+
+    def __repr__(self):
+        return "bottle_mongo.MongoPlugin(keyword=%r)" % (self.keyword)
 
     def normalize_object(self, obj):
         """Normalize mongo object for json serialization."""

--- a/bottle_mongo.py
+++ b/bottle_mongo.py
@@ -1,22 +1,31 @@
-
+# -*- coding: utf-8 -*-
 from bottle import PluginError, response
-from pymongo import Connection
-from pymongo.cursor import Cursor
 
-import bson.json_util
-from bottle import JSONPlugin
 try:
- from json import dumps as json_dumps
+    from pymongo import MongoClient, MongoReplicaSetClient
 except ImportError:
- from simplejson import dumps as json_dumps
+    # Backward compatibility with PyMongo 2.2
+    from pymongo import Connection as MongoClient
+    MongoReplicaSetClient = None
+
+from pymongo.cursor import Cursor
+from pymongo.uri_parser import parse_uri
+from bottle import JSONPlugin
+import bson.json_util
+
+try:
+    from json import dumps as json_dumps
+except ImportError:
+    from simplejson import dumps as json_dumps
 import inspect
+
 
 class MongoPlugin(object):
     """
     Mongo Plugin for Bottle
     Connect to a mongodb instance, and  add a DB in a Bottle callback
-    Sample : 
-    
+    Sample :
+
     app = bottle.Bottle()
     plugin = bottle.ext.mongo.MongoPlugin(uri="...", db="mydb", json_mongo=True)
     app.install(plugin)
@@ -26,68 +35,87 @@ class MongoPlugin(object):
         doc = mongodb['items'].find({item:"item")})
         return doc
     """
-    api  = 2
-    
+    api = 2
+
     mongo_db = None
+
     def get_mongo(self):
         "Retrieve the mongo instance from the environment"
-        if self.mongo_db: 
+        if self.mongo_db:
             return self.mongo_db
-        connection = Connection(self.uri, **self.kwargs)
-        self.mongo_db = connection[self.db]
-        return connection[self.db]
 
-    def __init__(self, uri, db, keyword='mongodb', json_mongo=False,  **kwargs):
+        if len(self.uri_params['nodelist']) > 1 and MongoReplicaSetClient:
+            client = MongoReplicaSetClient(self.uri_params['nodelist'], **self.uri_params['options'])
+        else:
+            client = MongoClient(self.uri_params['nodelist'][0][0], self.uri_params['nodelist'][0][1],
+                                 **self.uri_params['options'])
+
+        db = client[self.uri_params['database']]
+        if self.uri_params['username']:
+            if not db.authenticate(self.uri_params['username'], self.uri_params['password']):
+                raise PluginError('Cannot authenticate to MongoDB for user: %s' % self.uri_params['username'])
+
+        self.mongo_db = db
+        return self.mongo_db
+
+    def __init__(self, uri, db, keyword='mongodb', json_mongo=False, **kwargs):
         """
         uri : MongoDB hostname or uri
-        db : Database 
+        db : Database
         json_mongo : Override Bottle serializer using Mongo one
         keyword : Override parameter name in Bottle function.
-        This constructor any optional parameter of the pymongo.Connection constructor.  
+        This constructor any optional parameter of the pymongo.Connection constructor.
         """
-        self.uri = uri
-        self.db = db 
+        if not uri:
+            raise PluginError("MongoDB uri is required")
+
+        self.uri_params = parse_uri(uri)
+        if not len(self.uri_params['nodelist']):
+            raise PluginError("MongoDB hostname and port not configured")
+
+        self.uri_params['database'] = self.uri_params['database'] or db
+        if not self.uri_params['database']:
+            raise PluginError("MongoDB database name not configured")
+
+        self.uri_params['options'].update(kwargs)
+
         self.keyword = keyword
         self.json_mongo = json_mongo
-        self.kwargs = kwargs
 
     def normalize_object(self, obj):
-        "Normalize mongo object for json serialization"
+        """Normalize mongo object for json serialization"""
         if isinstance(obj, dict):
-            if "_id" in obj: 
+            if "_id" in obj:
                 obj["id"] = str(obj["_id"])
                 del obj["_id"]
         if isinstance(obj, list):
-            for a in obj: 
+            for a in obj:
                 self.normalize_object(a)
 
-
-
-    def setup(self,app):
+    def setup(self, app):
         for other in app.plugins:
-            if not isinstance(other,MongoPlugin): continue
+            if not isinstance(other, MongoPlugin): continue
             if other.keyword == self.keyword:
-                raise PluginError("Found another redis plugin with "\
-                        "conflicting settings (non-unique keyword).")
-                        
+                raise PluginError("Found another mongodb plugin with conflicting settings (non-unique keyword).")
+
         # Remove builtin JSON Plugin
         if self.json_mongo:
             for other in app.plugins:
-                if isinstance(other, JSONPlugin): 
+                if isinstance(other, JSONPlugin):
                     app.uninstall(other)
-                    return                         
+                    return
 
     def apply(self, callback, context):
         dumps = json_dumps
         if not dumps: return callback
-        
-        args = inspect.getargspec(context.callback)[0]        
-        
+
+        args = inspect.getargspec(context.callback)[0]
+
         def wrapper(*a, **ka):
             if self.keyword in args:
                 ka[self.keyword] = self.get_mongo()
             rv = callback(*a, **ka)
-            if self.json_mongo:  # Override builtin bottle JSON->String serializer  
+            if self.json_mongo:  # Override builtin bottle JSON->String serializer
                 if isinstance(rv, Cursor):
                     rv = [record for record in rv]
 
@@ -98,5 +126,6 @@ class MongoPlugin(object):
                     return json_response
 
             return rv
+
         return wrapper
 

--- a/bottle_mongo.py
+++ b/bottle_mongo.py
@@ -58,6 +58,7 @@ class MongoPlugin(object):
     db : Database
     json_mongo : Override Bottle serializer using Mongo one
     keyword : Override parameter name in Bottle function.
+    post_create : Callback function to customize database obj after creation.
 
     This constructor passes any optional parameter of the pymongo
     Connection/MongoClient/MongoReplicaSetClient constructor.
@@ -89,10 +90,15 @@ class MongoPlugin(object):
                 raise PluginError('Cannot authenticate to MongoDB for '
                                   'user: %s' % self.uri_params['username'])
 
+        if self.post_create:
+            db = self.post_create(db)
+
         self.mongo_db = db
+
         return self.mongo_db
 
-    def __init__(self, uri, db, keyword='mongodb', json_mongo=False, **kwargs):
+    def __init__(self, uri, db, keyword='mongodb', json_mongo=False,
+                 post_create=None, **kwargs):
         if not uri:
             raise PluginError("MongoDB uri is required")
 
@@ -110,6 +116,7 @@ class MongoPlugin(object):
         self.json_mongo = json_mongo
         self.mongo_db = None
         self.name = "mongo:" + keyword
+        self.post_create = post_create
 
     def __str__(self):
         return "bottle_mongo.MongoPlugin(keyword=%r)" % (self.keyword)

--- a/bottle_mongo.py
+++ b/bottle_mongo.py
@@ -67,7 +67,7 @@ class MongoPlugin(object):
         for other in app.plugins:
             if not isinstance(other,MongoPlugin): continue
             if other.keyword == self.keyword:
-                raise PluginError("Found another redis plugin with "\
+                raise PluginError("Found another MongoDB plugin with "\
                         "conflicting settings (non-unique keyword).")
                         
         # Remove builtin JSON Plugin

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except ImportError:
 
 setup(
     name = 'bottle-mongodb',
-    version = '0.2.1.1',
+    version = '0.2.1.2',
     url = 'https://github.com/fdouetteau/bottle-mongodb-plugin',
     description = 'MongoDB integration for Bottle',
     author = 'Florian Douetteau',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 try:
     from distutils.command.build_py import build_py_2to3 as build_py

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except ImportError:
 
 setup(
     name = 'bottle-mongodb',
-    version = '0.2.1.2',
+    version = '0.2.1.3',
     url = 'https://github.com/fdouetteau/bottle-mongodb-plugin',
     description = 'MongoDB integration for Bottle',
     author = 'Florian Douetteau',

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,8 @@ setup(
     ],
     classifiers = [
         'Environment :: Web Environment',
+        'Environment :: Plugins',
+        'Framework :: Bottle',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except ImportError:
 
 setup(
     name = 'bottle-mongodb',
-    version = '0.2.1',
+    version = '0.2.1.1',
     url = 'https://github.com/fdouetteau/bottle-mongodb-plugin',
     description = 'MongoDB integration for Bottle',
     author = 'Florian Douetteau',


### PR DESCRIPTION
I have gathered up other people's fixes I found on GitHub and made a few improvements like:
- supporting egg distributions
- Removed a check for a null json_dumps that can never be null.
- Only wrap the callback if there is something to be done to the callback.
- Remove support for returning lists.
  Due to security problems in browsers, it is not advisable to return
  lists as the top level item in a JSON response to a GET request.
  
  Removing the default support for it, so in scenarios where it would be
  supportable (POST for example), it is better to be explicit about what
  is happening.  See
  http://haacked.com/archive/2009/06/24/json-hijacking.aspx for details
  on the problem.
- Small cleanups for pep8 and pep257

I bumped the version number in the setup to 0.2.1.2, and if you accept this pull request, it would be great if you could push an update to PyPI.
